### PR TITLE
Refactored setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,10 @@ nosetests.xml
 # Dolphin
 .diredtory
 
+# Submodules
 planetlab-workload-traces
 pyCloudSim
+
+# Virtualenv related
+.pipcache
+env

--- a/setup/arch-setup.sh
+++ b/setup/arch-setup.sh
@@ -1,26 +1,10 @@
 #!/bin/bash
 
-PIP_CACHE='.pipcache'
-
-# source spawns on the current shell and exits, so we need this workaround
-# http://stackoverflow.com/a/13122219
-activate() {
-	source env/bin/activate
-}
+set -e
 
 # INSTAL DEPENDENCIES
 sudo pacman -Syy
 sudo pacman -S --noconfirm base-devel blas lapack gcc-fortran glpk
 sudo pacman -S --noconfirm python2 python2-pip python2-virtualenv
 
-# CREATE VIRTUAL ENV
-virtualenv2 env && activate
-
-# PYTHON PIP PACKAGES
-mkdir "${PIP_CACHE}"
-pip install --download-cache "${PIP_CACHE}" numpy==1.9.0
-pip install --download-cache "${PIP_CACHE}" FuncDesigner==0.5402
-pip install --download-cache "${PIP_CACHE}" openopt==0.5402
-pip install --download-cache "${PIP_CACHE}" matplotlib==1.4.0
-pip install --download-cache "${PIP_CACHE}" inspyred==1.0
-export CVXOPT_BUILD_GLPK=1 && pip install --download-cache "${PIP_CACHE}" cvxopt==1.1.7
+source python-setup.sh

--- a/setup/arch-setup.sh
+++ b/setup/arch-setup.sh
@@ -1,21 +1,26 @@
+#!/bin/bash
+
+PIP_CACHE='.pipcache'
+
+# source spawns on the current shell and exits, so we need this workaround
+# http://stackoverflow.com/a/13122219
+activate() {
+	source env/bin/activate
+}
+
 # INSTAL DEPENDENCIES
 sudo pacman -Syy
 sudo pacman -S --noconfirm base-devel blas lapack gcc-fortran glpk
 sudo pacman -S --noconfirm python2 python2-pip python2-virtualenv
 
-# FORCE PYTHON 2
-sudo ln -sf /usr/bin/python2 /usr/bin/python
-sudo ln -sf /usr/bin/pip2 /usr/bin/pip
-
 # CREATE VIRTUAL ENV
-virtualenv2 env
-source env/bin/activate
+virtualenv2 env && activate
 
 # PYTHON PIP PACKAGES
-mkdir ~/.pipcache
-source env/bin/activate && pip install --download-cache ~/.pipcache numpy==1.9.0
-source env/bin/activate && pip install --download-cache ~/.pipcache FuncDesigner==0.5402
-source env/bin/activate && pip install --download-cache ~/.pipcache openopt==0.5402
-source env/bin/activate && pip install --download-cache ~/.pipcache matplotlib==1.4.0
-source env/bin/activate && pip install --download-cache ~/.pipcache inspyred==1.0
-source env/bin/activate && export CVXOPT_BUILD_GLPK=1 && pip install --download-cache ~/.pipcache cvxopt==1.1.7
+mkdir "${PIP_CACHE}"
+pip install --download-cache "${PIP_CACHE}" numpy==1.9.0
+pip install --download-cache "${PIP_CACHE}" FuncDesigner==0.5402
+pip install --download-cache "${PIP_CACHE}" openopt==0.5402
+pip install --download-cache "${PIP_CACHE}" matplotlib==1.4.0
+pip install --download-cache "${PIP_CACHE}" inspyred==1.0
+export CVXOPT_BUILD_GLPK=1 && pip install --download-cache "${PIP_CACHE}" cvxopt==1.1.7

--- a/setup/debian-setup.sh
+++ b/setup/debian-setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# INSTAL DEPENDENCIES
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update
+sudo apt-get install --yes build-essential libblas-dev liblapack-dev gfortran libglpk-dev libpng-dev libfreetype6-dev
+sudo apt-get install --yes python python-dev python-pip python-virtualenv
+
+source python-setup.sh

--- a/setup/python-setup.sh
+++ b/setup/python-setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+PIP_CACHE='.pipcache'
+
+# source spawns on the current shell and exits, so we need this workaround
+# http://stackoverflow.com/a/13122219
+activate() {
+	source env/bin/activate
+}
+
+# CREATE VIRTUAL ENV
+if hash virtualenv2 2>/dev/null; then
+	virtualenv2 env
+else
+	virtualenv env
+fi
+
+# ACTIVATE VIRTUAL ENV
+activate
+
+# PYTHON PIP PACKAGES
+mkdir -p "${PIP_CACHE}"
+pip install --download-cache "${PIP_CACHE}" numpy==1.9.0
+pip install --download-cache "${PIP_CACHE}" FuncDesigner==0.5402
+pip install --download-cache "${PIP_CACHE}" openopt==0.5402
+pip install --download-cache "${PIP_CACHE}" matplotlib==1.4.0
+pip install --download-cache "${PIP_CACHE}" inspyred==1.0
+export CVXOPT_BUILD_GLPK=1 && pip install --download-cache "${PIP_CACHE}" cvxopt==1.1.7


### PR DESCRIPTION
There is no need to symlink `python2` to `python`, since we are working inside a Virtualenv. Using a workaround to allow the sourcing of Virtualenv's `activate` without calling it each time we use it too.
